### PR TITLE
Fix enabling nuget package be referenced in .NET <4.6 projects

### DIFF
--- a/src/xunit2.ioc.autofac/project.json
+++ b/src/xunit2.ioc.autofac/project.json
@@ -20,6 +20,11 @@
     "tags": [ "xunit", "autofac" ]
   },
 
+  "System.Runtime": {
+    "type": "build",
+    "version": ""
+  },
+
   "frameworks": {
     "netstandard1.6": {
       "imports": "dnxcore50",


### PR DESCRIPTION
Fix for #5 
Solution found here: https://github.com/aspnet/Home/issues/1157
I haven't tested uploading new nuget package. It'd make the original package less popular.
